### PR TITLE
fix: app crashes on Heroku

### DIFF
--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -140,17 +140,10 @@ export class AstarFaucetApi {
 
     public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
         try {
-            console.log('connect network');
             await this.connectTo(network);
-            console.log('await isReady');
-            await this._api.isReady;
-            console.log('properties()');
-            const properties = await this._api.rpc.system.properties();
-            console.log('tokenSymbol');
-            const tokenSymbol = properties.tokenSymbol.toJSON() as string[];
-            console.log('tokenSymbol[0]', tokenSymbol[0]);
-            return tokenSymbol[0];
-            // return await this._api.rpc.system.properties;
+            const tokenSymbol = formatBalance.getDefaults().unit;
+            console.log('tokenSymbol', tokenSymbol);
+            return tokenSymbol;
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (error: any) {
             console.error(error.message);

--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -138,35 +138,35 @@ export class AstarFaucetApi {
             .signAndSend(this._faucetAccount, { nonce: -1 });
     }
 
-    public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
-        try {
-            await this.connectTo(network);
-            const properties = await this._api.rpc.system.properties();
-            const tokenSymbol = properties.tokenSymbol.toJSON() as string[];
-            return tokenSymbol[0];
-            // return await this._api.rpc.system.properties;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            console.error(error.message);
-            return 'Something went wrong';
-        }
-        // switch (network) {
-        //     case Network.shiden:
-        //         return 'SDN';
-
-        //     case Network.shibuya:
-        //         return 'SBY';
-
-        //     case Network.dusty:
-        //         return 'PLD';
-
-        //     // Enable after ASTR is launched
-        //     // case Network.astar:
-        //     //     return true
-
-        //     default:
-        //         return 'SBY';
+    public getNetworkUnit({ network }: { network: NetworkName }): string {
+        // try {
+        // await this.connectTo(network);
+        // const properties = await this._api.rpc.system.properties();
+        // const tokenSymbol = properties.tokenSymbol.toJSON() as string[];
+        // return tokenSymbol[0];
+        // return await this._api.rpc.system.properties;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // } catch (error: any) {
+        //     console.error(error.message);
+        //     return 'Something went wrong';
         // }
+        switch (network) {
+            case Network.shiden:
+                return 'SDN';
+
+            case Network.shibuya:
+                return 'SBY';
+
+            case Network.dusty:
+                return 'PLD';
+
+            // Enable after ASTR is launched
+            // case Network.astar:
+            //     return true
+
+            default:
+                return 'SBY';
+        }
     }
 
     public async getBalanceStatus({

--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -138,35 +138,41 @@ export class AstarFaucetApi {
             .signAndSend(this._faucetAccount, { nonce: -1 });
     }
 
-    public getNetworkUnit({ network }: { network: NetworkName }): string {
-        // try {
-        // await this.connectTo(network);
-        // const properties = await this._api.rpc.system.properties();
-        // const tokenSymbol = properties.tokenSymbol.toJSON() as string[];
-        // return tokenSymbol[0];
-        // return await this._api.rpc.system.properties;
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        // } catch (error: any) {
-        //     console.error(error.message);
-        //     return 'Something went wrong';
-        // }
-        switch (network) {
-            case Network.shiden:
-                return 'SDN';
-
-            case Network.shibuya:
-                return 'SBY';
-
-            case Network.dusty:
-                return 'PLD';
-
-            // Enable after ASTR is launched
-            // case Network.astar:
-            //     return true
-
-            default:
-                return 'SBY';
+    public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
+        try {
+            console.log('connect network');
+            await this.connectTo(network);
+            console.log('await isReady');
+            await this._api.isReady;
+            console.log('properties()');
+            const properties = await this._api.rpc.system.properties();
+            console.log('tokenSymbol');
+            const tokenSymbol = properties.tokenSymbol.toJSON() as string[];
+            console.log('tokenSymbol[0]', tokenSymbol[0]);
+            return tokenSymbol[0];
+            // return await this._api.rpc.system.properties;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            console.error(error.message);
+            return 'Something went wrong';
         }
+        // switch (network) {
+        //     case Network.shiden:
+        //         return 'SDN';
+
+        //     case Network.shibuya:
+        //         return 'SBY';
+
+        //     case Network.dusty:
+        //         return 'PLD';
+
+        //     // Enable after ASTR is launched
+        //     // case Network.astar:
+        //     //     return true
+
+        //     default:
+        //         return 'SBY';
+        // }
     }
 
     public async getBalanceStatus({

--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -138,14 +138,32 @@ export class AstarFaucetApi {
             .signAndSend(this._faucetAccount, { nonce: -1 });
     }
 
-    public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
-        try {
-            await this.connectTo(network);
-            return this._api.registry.chainTokens[0];
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            console.error(error.message);
-            return 'Something went wrong';
+    public getNetworkUnit({ network }: { network: NetworkName }): string {
+        // try {
+        //     console.log('network', network);
+        //     await this.connectTo(network);
+        //     return this._api.registry.chainTokens[0];
+        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // } catch (error: any) {
+        //     console.error(error.message);
+        //     return 'Something went wrong';
+        // }
+        switch (network) {
+            case Network.shiden:
+                return 'SDN';
+
+            case Network.shibuya:
+                return 'SBY';
+
+            case Network.dusty:
+                return 'PLD';
+
+            // Enable after ASTR is launched
+            // case Network.astar:
+            //     return true
+
+            default:
+                return 'SBY';
         }
     }
 

--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -138,33 +138,35 @@ export class AstarFaucetApi {
             .signAndSend(this._faucetAccount, { nonce: -1 });
     }
 
-    public getNetworkUnit({ network }: { network: NetworkName }): string {
-        // try {
-        //     console.log('network', network);
-        //     await this.connectTo(network);
-        //     return this._api.registry.chainTokens[0];
-        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        // } catch (error: any) {
-        //     console.error(error.message);
-        //     return 'Something went wrong';
-        // }
-        switch (network) {
-            case Network.shiden:
-                return 'SDN';
-
-            case Network.shibuya:
-                return 'SBY';
-
-            case Network.dusty:
-                return 'PLD';
-
-            // Enable after ASTR is launched
-            // case Network.astar:
-            //     return true
-
-            default:
-                return 'SBY';
+    public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
+        try {
+            await this.connectTo(network);
+            const properties = await this._api.rpc.system.properties();
+            const tokenSymbol = properties.tokenSymbol.toJSON() as string[];
+            return tokenSymbol[0];
+            // return await this._api.rpc.system.properties;
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } catch (error: any) {
+            console.error(error.message);
+            return 'Something went wrong';
         }
+        // switch (network) {
+        //     case Network.shiden:
+        //         return 'SDN';
+
+        //     case Network.shibuya:
+        //         return 'SBY';
+
+        //     case Network.dusty:
+        //         return 'PLD';
+
+        //     // Enable after ASTR is launched
+        //     // case Network.astar:
+        //     //     return true
+
+        //     default:
+        //         return 'SBY';
+        // }
     }
 
     public async getBalanceStatus({

--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -139,33 +139,33 @@ export class AstarFaucetApi {
     }
 
     public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
-        try {
-            await this.connectTo(network);
-            const tokenSymbol = formatBalance.getDefaults().unit;
-            console.log('tokenSymbol', tokenSymbol);
-            return tokenSymbol;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
-            console.error(error.message);
-            return 'Something went wrong';
-        }
-        // switch (network) {
-        //     case Network.shiden:
-        //         return 'SDN';
-
-        //     case Network.shibuya:
-        //         return 'SBY';
-
-        //     case Network.dusty:
-        //         return 'PLD';
-
-        //     // Enable after ASTR is launched
-        //     // case Network.astar:
-        //     //     return true
-
-        //     default:
-        //         return 'SBY';
+        // try {
+        //     await this.connectTo(network);
+        //     const tokenSymbol = formatBalance.getDefaults().unit;
+        //     console.log('tokenSymbol', tokenSymbol);
+        //     return tokenSymbol;
+        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // } catch (error: any) {
+        //     console.error(error.message);
+        //     return 'Something went wrong';
         // }
+        switch (network) {
+            case Network.shiden:
+                return 'SDN';
+
+            case Network.shibuya:
+                return 'SBY';
+
+            case Network.dusty:
+                return 'PLD';
+
+            // Enable after ASTR is launched
+            // case Network.astar:
+            //     return true
+
+            default:
+                return 'SBY';
+        }
     }
 
     public async getBalanceStatus({

--- a/src/clients/astar.ts
+++ b/src/clients/astar.ts
@@ -1,4 +1,4 @@
-import { checkIsMainnet } from './../modules/faucet/utils/index';
+import { checkIsMainnet, getTokenUnit } from './../modules/faucet/utils/index';
 import { ApiPromise, WsProvider, Keyring } from '@polkadot/api';
 import { appConfig } from '../config';
 import { formatBalance } from '@polkadot/util';
@@ -138,36 +138,6 @@ export class AstarFaucetApi {
             .signAndSend(this._faucetAccount, { nonce: -1 });
     }
 
-    public async getNetworkUnit({ network }: { network: NetworkName }): Promise<string> {
-        // try {
-        //     await this.connectTo(network);
-        //     const tokenSymbol = formatBalance.getDefaults().unit;
-        //     console.log('tokenSymbol', tokenSymbol);
-        //     return tokenSymbol;
-        //     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        // } catch (error: any) {
-        //     console.error(error.message);
-        //     return 'Something went wrong';
-        // }
-        switch (network) {
-            case Network.shiden:
-                return 'SDN';
-
-            case Network.shibuya:
-                return 'SBY';
-
-            case Network.dusty:
-                return 'PLD';
-
-            // Enable after ASTR is launched
-            // case Network.astar:
-            //     return true
-
-            default:
-                return 'SBY';
-        }
-    }
-
     public async getBalanceStatus({
         network,
     }: {
@@ -191,9 +161,8 @@ export class AstarFaucetApi {
 
     public async checkFaucetBalance({ network }: { network: Network }): Promise<{ balance: number; unit: string }> {
         try {
-            const results = await Promise.all([this.getBalanceStatus({ network }), this.getNetworkUnit({ network })]);
-            const { balance, isShortage } = results[0];
-            const unit = results[1];
+            const { balance, isShortage } = await this.getBalanceStatus({ network });
+            const unit = getTokenUnit(network);
 
             const endpoint = process.env.DISCORD_WEBHOOK_URL;
             const mentionId = process.env.DISCORD_MENTION_ID;

--- a/src/clients/express.ts
+++ b/src/clients/express.ts
@@ -48,7 +48,7 @@ export const expressApp = async (astarApi: AstarFaucetApi) => {
         try {
             const network: Network = req.params.network as Network;
             const address: string = req.query.destination as string;
-            const { timestamps, faucet } = await getFaucetInfo({ network, address, astarApi });
+            const { timestamps, faucet } = await getFaucetInfo({ network, address });
             return res.status(200).json({ timestamps, faucet });
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/middlewares/requestFilter.ts
+++ b/src/middlewares/requestFilter.ts
@@ -4,8 +4,7 @@ const redis = new Redis(process.env.REDIS_URL);
 
 // Cooldown time in millisecond.
 // The requester must wait for Cooldown time to request next faucet.
-const testnetCooldownTimeMillisecond = 60 * 60 * 10;
-// const testnetCooldownTimeMillisecond = 60 * 60 * 1000;
+const testnetCooldownTimeMillisecond = 60 * 60 * 1000;
 const mainnetCooldownTimeMillisecond = 60 * 60 * 48 * 1000;
 
 // Check whether the requester can request Faucet or not based on the last request time.

--- a/src/middlewares/requestFilter.ts
+++ b/src/middlewares/requestFilter.ts
@@ -4,7 +4,8 @@ const redis = new Redis(process.env.REDIS_URL);
 
 // Cooldown time in millisecond.
 // The requester must wait for Cooldown time to request next faucet.
-const testnetCooldownTimeMillisecond = 60 * 60 * 1000;
+const testnetCooldownTimeMillisecond = 60 * 60 * 10;
+// const testnetCooldownTimeMillisecond = 60 * 60 * 1000;
 const mainnetCooldownTimeMillisecond = 60 * 60 * 48 * 1000;
 
 // Check whether the requester can request Faucet or not based on the last request time.

--- a/src/modules/faucet/utils/index.ts
+++ b/src/modules/faucet/utils/index.ts
@@ -24,6 +24,23 @@ export const checkIsMainnet = (network: Network): boolean => {
     }
 };
 
+export const getTokenUnit = (network: Network): string => {
+    switch (network) {
+        case Network.shiden:
+            return 'SDN';
+        case Network.shibuya:
+            return 'SBY';
+        case Network.dusty:
+            return 'PLD';
+        // Enable after ASTR is launched
+        // case Network.astar:
+        //     return ASTR
+
+        default:
+            return 'SBY';
+    }
+};
+
 export const getFaucetAmount = (network: Network): number => {
     const isMainnet = checkIsMainnet(network);
     const amount = isMainnet ? Number(MAINNET_FAUCET_AMOUNT) : Number(TESTNET_FAUCET_AMOUNT);
@@ -44,26 +61,12 @@ export const generateFaucetId = ({ network, address }: { network: NetworkName; a
     return `${network}:${address}`;
 };
 
-export const getFaucetInfo = async ({
-    network,
-    address,
-    astarApi,
-}: {
-    network: Network;
-    address: string;
-    astarApi: AstarFaucetApi;
-}) => {
+export const getFaucetInfo = async ({ network, address }: { network: Network; address: string }) => {
     const isMainnet = checkIsMainnet(network);
     const requesterId = generateFaucetId({ network, address });
 
-    const results = await Promise.all([
-        getRequestTimestamps({ requesterId, isMainnet }),
-        astarApi.getNetworkUnit({ network }),
-    ]);
-    const timestamps = results[0];
-    const unit = results[1];
-
-    console.log('unit', unit);
+    const timestamps = await getRequestTimestamps({ requesterId, isMainnet });
+    const unit = getTokenUnit(network);
 
     const faucet = {
         amount: getFaucetAmount(network),

--- a/src/modules/faucet/utils/index.ts
+++ b/src/modules/faucet/utils/index.ts
@@ -63,6 +63,8 @@ export const getFaucetInfo = async ({
     const timestamps = results[0];
     const unit = results[1];
 
+    console.log('unit', unit);
+
     const faucet = {
         amount: getFaucetAmount(network),
         unit,


### PR DESCRIPTION
The code below [(getNetowrkUnit method)](https://github.com/AstarNetwork/astar-faucet-bot/compare/main...fix/app-crash#diff-ef3461cf857995a92a614fae2192b54dbfc7c67cbe94a39bfbbf49f480788d33L143) makes app crashes (only on Heroku server).  To prevent crashes, I created a function that returns the token unit value without using the Astar API.

```
await this.connectTo(network);
return this._api.registry.chainTokens[0];
```

Green square: The update is reflected here. (more than 12hrs)
![image](https://user-images.githubusercontent.com/92044428/148529598-53a1094a-ba7a-4bdb-8d02-81472f1587a1.png)
