### PR TITLE
fix: address in alert message

### DIFF
--- a/src/modules/faucet/utils/evm/index.ts
+++ b/src/modules/faucet/utils/evm/index.ts
@@ -91,7 +91,7 @@ export const evmFaucet = async ({
 
     const balance = await web3.eth.getBalance(hotWallet.address);
     const formattedBalance = web3.utils.fromWei(balance, 'ether');
-    await checkIsShortage({ network, address, balance: Number(formattedBalance) });
+    await checkIsShortage({ network, address: hotWallet.address, balance: Number(formattedBalance) });
 
     return { blockNumber, blockHash };
 };

--- a/src/modules/faucet/utils/evm/index.ts
+++ b/src/modules/faucet/utils/evm/index.ts
@@ -71,6 +71,10 @@ export const evmFaucet = async ({
     }
 
     const hotWallet = web3.eth.accounts.privateKeyToAccount(privateKey);
+    const balance = await web3.eth.getBalance(hotWallet.address);
+    const formattedBalance = web3.utils.fromWei(balance, 'ether');
+    await checkIsShortage({ network, address: hotWallet.address, balance: Number(formattedBalance) });
+
     const transaction: TransactionConfig = {
         nonce: await web3.eth.getTransactionCount(hotWallet.address),
         value: web3.utils.toHex(dripAmount),
@@ -88,10 +92,6 @@ export const evmFaucet = async ({
     }
 
     const { blockNumber, blockHash } = await web3.eth.sendSignedTransaction(signedTx.rawTransaction);
-
-    const balance = await web3.eth.getBalance(hotWallet.address);
-    const formattedBalance = web3.utils.fromWei(balance, 'ether');
-    await checkIsShortage({ network, address: hotWallet.address, balance: Number(formattedBalance) });
 
     return { blockNumber, blockHash };
 };


### PR DESCRIPTION
* Fixed `address` displayed on the warning message
* Check the balance before send the transaction

![image](https://user-images.githubusercontent.com/92044428/151223123-57292b8d-6606-495d-a122-405291828e9f.png)
